### PR TITLE
Removed std:: specifications for Scalar objects. This allows the comp…

### DIFF
--- a/include/GenEigsComplexShiftSolver.h
+++ b/include/GenEigsComplexShiftSolver.h
@@ -61,14 +61,14 @@ private:
         // We can use this identity to back-solve lambdai
 
         // Select an arbitrary real shift value
-        Scalar r = sigmar + std::sin(sigmar);
+        Scalar r = sigmar + sin(sigmar);
         this->m_op->set_shift(r, 0);
 
         // Calculate inv(A - r * I) * vi
         ComplexArray v;
         Array v_real, v_imag;
         Array lhs_real(this->m_n), lhs_imag(this->m_n);
-        Scalar eps = std::pow(std::numeric_limits<Scalar>::epsilon(), Scalar(2.0) / 3);
+        Scalar eps = pow(std::numeric_limits<Scalar>::epsilon(), Scalar(2.0) / 3);
         for(int i = 0; i < this->m_nev; i++)
         {
             v = this->m_fac_V * this->m_ritz_vec.col(i);
@@ -82,7 +82,7 @@ private:
                               Complex(r, 0);
             this->m_ritz_val[i] = lambdai;
 
-            if(std::abs(lambdai.imag()) > eps)
+            if(abs(lambdai.imag()) > eps)
             {
                 this->m_ritz_val[i + 1] = std::conj(lambdai);
                 i++;

--- a/include/GenEigsSolver.h
+++ b/include/GenEigsSolver.h
@@ -9,9 +9,9 @@
 
 #include <Eigen/Core>
 #include <vector>     // std::vector
-#include <cmath>      // std::abs, std::pow
+//#include <cmath>      // std::abs, std::pow
 #include <algorithm>  // std::min, std::copy
-#include <complex>    // std::complex, std::conj, std::norm
+#include <complex>    // std::complex, std::conj, std::norm, std::abs
 #include <limits>     // std::numeric_limits
 #include <stdexcept>  // std::invalid_argument
 
@@ -259,7 +259,7 @@ private:
 
     static bool is_complex(Complex v, Scalar eps)
     {
-        return std::abs(v.imag()) > eps;
+        return abs(v.imag()) > eps;
     }
 
     static bool is_conj(Complex v1, Complex v2, Scalar eps)
@@ -351,7 +351,7 @@ private:
         int nev_new = m_nev;
 
         for(int i = m_nev; i < m_ncv; i++)
-            if(std::abs(m_ritz_est[i]) < m_prec)  nev_new++;
+            if(abs(m_ritz_est[i]) < m_prec)  nev_new++;
 
         // Increase nev by one if m_ritz_val[nev - 1] and
         // m_ritz_val[nev] are conjugate pairs
@@ -491,7 +491,7 @@ public:
         m_nmatop(0),
         m_niter(0),
         m_info(NOT_COMPUTED),
-        m_prec(std::pow(std::numeric_limits<Scalar>::epsilon(), Scalar(2.0) / 3))
+        m_prec(pow(std::numeric_limits<Scalar>::epsilon(), Scalar(2.0) / 3))
     {
         if(nev_ < 1 || nev_ > m_n - 2)
             throw std::invalid_argument("nev must satisfy 1 <= nev <= n - 2, n is the size of matrix");

--- a/include/LinAlg/DoubleShiftQR.h
+++ b/include/LinAlg/DoubleShiftQR.h
@@ -10,7 +10,7 @@
 #include <Eigen/Core>
 #include <vector>     // std::vector
 #include <algorithm>  // std::min, std::fill, std::copy
-#include <cmath>      // std::abs, std::sqrt, std::pow
+//#include <cmath>      // std::abs, std::sqrt, std::pow
 #include <limits>     // std::numeric_limits
 #include <stdexcept>  // std::invalid_argument, std::logic_error
 
@@ -52,10 +52,10 @@ private:
         // In general case the reflector affects 3 rows
         nr[ind] = 3;
         // If x3 is zero, decrease nr by 1
-        if(std::abs(x3) < m_prec)
+        if(abs(x3) < m_prec)
         {
             // If x2 is also zero, nr will be 1, and we can exit this function
-            if(std::abs(x2) < m_prec)
+            if(abs(x2) < m_prec)
             {
                 nr[ind] = 1;
                 return;
@@ -67,8 +67,8 @@ private:
         // x1' = x1 - rho * ||x||
         // rho = -sign(x1), if x1 == 0, we choose rho = 1
         Scalar tmp = x2 * x2 + x3 * x3;
-        Scalar x1_new = x1 - ((x1 <= 0) - (x1 > 0)) * std::sqrt(x1 * x1 + tmp);
-        Scalar x_norm = std::sqrt(x1_new * x1_new + tmp);
+        Scalar x1_new = x1 - ((x1 <= 0) - (x1 > 0)) * sqrt(x1 * x1 + tmp);
+        Scalar x_norm = sqrt(x1_new * x1_new + tmp);
         // Double check the norm of new x
         if(x_norm < m_prec)
         {
@@ -247,8 +247,8 @@ public:
     DoubleShiftQR(Index size) :
         m_n(size),
         m_prec(std::numeric_limits<Scalar>::epsilon()),
-        m_eps_rel(std::pow(m_prec, Scalar(0.75))),
-        m_eps_abs(std::min(std::pow(m_prec, Scalar(0.75)), m_n * m_prec)),
+        m_eps_rel(pow(m_prec, Scalar(0.75))),
+        m_eps_abs(min(pow(m_prec, Scalar(0.75)), m_n * m_prec)),
         m_computed(false)
     {}
 
@@ -260,8 +260,8 @@ public:
         m_ref_u(3, m_n),
         m_ref_nr(m_n),
         m_prec(std::numeric_limits<Scalar>::epsilon()),
-        m_eps_rel(std::pow(m_prec, Scalar(0.75))),
-        m_eps_abs(std::min(std::pow(m_prec, Scalar(0.75)), m_n * m_prec)),
+        m_eps_rel(pow(m_prec, Scalar(0.75))),
+        m_eps_abs(min(pow(m_prec, Scalar(0.75)), m_n * m_prec)),
         m_computed(false)
     {
         compute(mat, s, t);
@@ -291,8 +291,8 @@ public:
         for(Index i = 0; i < m_n - 2; i++, Hii += (m_n + 1))
         {
             // Hii[1] => m_mat_H(i + 1, i)
-            const Scalar h = std::abs(Hii[1]);
-            if(h <= m_eps_abs || h <= m_eps_rel * (std::abs(Hii[0]) + std::abs(Hii[m_n + 1])))
+            const Scalar h = abs(Hii[1]);
+            if(h <= m_eps_abs || h <= m_eps_rel * (abs(Hii[0]) + abs(Hii[m_n + 1])))
             {
                 Hii[1] = 0;
                 zero_ind.push_back(i + 1);

--- a/include/LinAlg/TridiagEigen.h
+++ b/include/LinAlg/TridiagEigen.h
@@ -61,7 +61,7 @@ private:
         // This explain the following, somewhat more complicated, version:
         RealScalar mu = diag[end];
         if(td == 0)
-            mu -= std::abs(e);
+            mu -= abs(e);
         else
         {
             RealScalar e2 = Eigen::numext::abs2(subdiag[end-1]);
@@ -138,7 +138,7 @@ public:
         while(end > 0)
         {
             for(Index i = start; i < end; i++)
-                if(is_much_smaller_than(std::abs(subd[i]), (std::abs(maind[i]) + std::abs(maind[i + 1]))))
+                if(is_much_smaller_than(abs(subd[i]), (abs(maind[i]) + abs(maind[i + 1]))))
                     subd[i] = 0;
 
             // find the largest unreduced block

--- a/include/LinAlg/UpperHessenbergEigen.h
+++ b/include/LinAlg/UpperHessenbergEigen.h
@@ -46,7 +46,7 @@ private:
     static Complex cdiv(const Scalar& xr, const Scalar& xi, const Scalar& yr, const Scalar& yi)
     {
         Scalar r, d;
-        if(std::abs(yr) > std::abs(yi))
+        if(abs(yr) > abs(yi))
         {
             r = yi/yr;
             d = yr + r*yi;
@@ -111,14 +111,14 @@ private:
                             Scalar denom = (m_eivalues.coeff(i).real() - p) * (m_eivalues.coeff(i).real() - p) + m_eivalues.coeff(i).imag() * m_eivalues.coeff(i).imag();
                             Scalar t = (x * lastr - lastw * r) / denom;
                             m_matT.coeffRef(i,n) = t;
-                            if(std::abs(x) > std::abs(lastw))
+                            if(abs(x) > abs(lastw))
                                 m_matT.coeffRef(i+1,n) = (-r - w * t) / x;
                             else
                                 m_matT.coeffRef(i+1,n) = (-lastr - y * t) / lastw;
                         }
 
                         // Overflow control
-                        Scalar t = std::abs(m_matT.coeff(i,n));
+                        Scalar t = abs(m_matT.coeff(i,n));
                         if((eps * t) * t > Scalar(1))
                             m_matT.col(n).tail(size-i) /= t;
                     }
@@ -128,7 +128,7 @@ private:
                 Index l = n-1;
 
                 // Last vector component imaginary so matrix is triangular
-                if(std::abs(m_matT.coeff(n,n-1)) > std::abs(m_matT.coeff(n-1,n)))
+                if(abs(m_matT.coeff(n,n-1)) > abs(m_matT.coeff(n-1,n)))
                 {
                     m_matT.coeffRef(n-1,n-1) = q / m_matT.coeff(n,n-1);
                     m_matT.coeffRef(n-1,n) = -(m_matT.coeff(n,n) - p) / m_matT.coeff(n,n-1);
@@ -170,12 +170,12 @@ private:
                             Scalar vr = (m_eivalues.coeff(i).real() - p) * (m_eivalues.coeff(i).real() - p) + m_eivalues.coeff(i).imag() * m_eivalues.coeff(i).imag() - q * q;
                             Scalar vi = (m_eivalues.coeff(i).real() - p) * Scalar(2) * q;
                             if((vr == 0.0) && (vi == 0.0))
-                                vr = eps * norm * (std::abs(w) + std::abs(q) + std::abs(x) + std::abs(y) + std::abs(lastw));
+                                vr = eps * norm * (abs(w) + abs(q) + abs(x) + abs(y) + abs(lastw));
 
                             Complex cc = cdiv(x*lastra-lastw*ra+q*sa, x*lastsa-lastw*sa-q*ra, vr, vi);
                             m_matT.coeffRef(i,n-1) = cc.real();
                             m_matT.coeffRef(i,n) = cc.imag();
-                            if(std::abs(x) > (std::abs(lastw) + std::abs(q)))
+                            if(abs(x) > (abs(lastw) + abs(q)))
                             {
                                 m_matT.coeffRef(i+1,n-1) = (-ra - w * m_matT.coeff(i,n-1) + q * m_matT.coeff(i,n)) / x;
                                 m_matT.coeffRef(i+1,n) = (-sa - w * m_matT.coeff(i,n) - q * m_matT.coeff(i,n-1)) / x;
@@ -189,7 +189,7 @@ private:
                         }
 
                         // Overflow control
-                        Scalar t = std::max(std::abs(m_matT.coeff(i,n-1)), std::abs(m_matT.coeff(i,n)));
+                        Scalar t = max(abs(m_matT.coeff(i,n-1)), abs(m_matT.coeff(i,n)));
                         if((eps * t) * t > Scalar(1))
                             m_matT.block(i, n-1, size-i, 2) /= t;
 
@@ -249,7 +249,7 @@ public:
             else  // Complex eigenvalues
             {
                 Scalar p = Scalar(0.5) * (m_matT.coeff(i, i) - m_matT.coeff(i+1, i+1));
-                Scalar z = std::sqrt(std::abs(p * p + m_matT.coeff(i+1, i) * m_matT.coeff(i, i+1)));
+                Scalar z = sqrt(abs(p * p + m_matT.coeff(i+1, i) * m_matT.coeff(i, i+1)));
                 m_eivalues.coeffRef(i)   = Complex(m_matT.coeff(i+1, i+1) + p, z);
                 m_eivalues.coeffRef(i+1) = Complex(m_matT.coeff(i+1, i+1) + p, -z);
                 i += 2;
@@ -276,12 +276,12 @@ public:
             throw std::logic_error("UpperHessenbergEigen: need to call compute() first");
 
         Index n = m_eivec.cols();
-        const Scalar prec = std::pow(std::numeric_limits<Scalar>::epsilon(), Scalar(2.0) / 3);
+        const Scalar prec = pow(std::numeric_limits<Scalar>::epsilon(), Scalar(2.0) / 3);
 
         ComplexMatrix matV(n, n);
         for(Index j = 0; j < n; ++j)
         {
-            if(std::abs(m_eivalues.coeff(j).imag()) <= prec || j + 1 == n)
+            if(abs(m_eivalues.coeff(j).imag()) <= prec || j + 1 == n)
             {
                 // we have a real eigen value
                 matV.col(j) = m_eivec.col(j).template cast<Complex>();

--- a/include/LinAlg/UpperHessenbergQR.h
+++ b/include/LinAlg/UpperHessenbergQR.h
@@ -8,7 +8,7 @@
 #define UPPER_HESSENBERG_QR_H
 
 #include <Eigen/Core>
-#include <cmath>      // std::sqrt
+//#include <cmath>      // std::sqrt
 #include <algorithm>  // std::fill, std::copy
 #include <limits>     // std::numeric_limits
 #include <stdexcept>  // std::logic_error
@@ -112,7 +112,7 @@ public:
 
             xi = Tii[0];  // mat_T(i, i)
             xj = Tii[1];  // mat_T(i + 1, i)
-            r = std::sqrt(xi * xi + xj * xj);
+            r = sqrt(xi * xi + xj * xj);
             if(r <= eps)
             {
                 r = 0;
@@ -477,7 +477,7 @@ public:
         {
             // Tii[0] == T[i, i]
             // Tii[1] == T[i + 1, i]
-            r = std::sqrt(Tii[0] * Tii[0] + Tii[1] * Tii[1]);
+            r = sqrt(Tii[0] * Tii[0] + Tii[1] * Tii[1]);
             if(r <= eps)
             {
                 r = 0;
@@ -527,7 +527,7 @@ public:
             // this->m_mat_T(i + 1, i + 2) *= (*c);
         }
         // For i = n - 2
-        r = std::sqrt(Tii[0] * Tii[0] + Tii[1] * Tii[1]);
+        r = sqrt(Tii[0] * Tii[0] + Tii[1] * Tii[1]);
         if(r <= eps)
         {
             r = 0;

--- a/include/SymEigsSolver.h
+++ b/include/SymEigsSolver.h
@@ -10,7 +10,7 @@
 #include <Eigen/Core>
 #include <Eigen/Eigenvalues>
 #include <vector>     // std::vector
-#include <cmath>      // std::abs, std::pow
+//#include <cmath>      // std::abs, std::pow
 #include <algorithm>  // std::min, std::copy
 #include <limits>     // std::numeric_limits
 #include <stdexcept>  // std::invalid_argument
@@ -341,7 +341,7 @@ private:
         int nev_new = m_nev;
 
         for(int i = m_nev; i < m_ncv; i++)
-            if(std::abs(m_ritz_est[i]) < m_prec)  nev_new++;
+            if(abs(static_cast<Scalar>(m_ritz_est[i])) < m_prec)  nev_new++;
 
         // Adjust nev_new, according to dsaup2.f line 677~684 in ARPACK
         nev_new += std::min(nconv, (m_ncv - nev_new) / 2);
@@ -456,7 +456,7 @@ public:
     ///             the matrix-vector multiplication operation of \f$A\f$:
     ///             calculating \f$Ay\f$ for any vector \f$y\f$. Users could either
     ///             create the object from the wrapper class such as DenseSymMatProd, or
-    ///             define their own that impelemnts all the public member functions
+    ///             define their own that impelements all the public member functions
     ///             as in DenseSymMatProd.
     /// \param nev_ Number of eigenvalues requested. This should satisfy \f$1\le nev \le n-1\f$,
     ///             where \f$n\f$ is the size of matrix.
@@ -474,7 +474,7 @@ public:
         m_nmatop(0),
         m_niter(0),
         m_info(NOT_COMPUTED),
-        m_prec(std::pow(std::numeric_limits<Scalar>::epsilon(), Scalar(2.0) / 3))
+        m_prec(pow(std::numeric_limits<Scalar>::epsilon(), Scalar(2.0) / 3))
     {
         if(nev_ < 1 || nev_ > m_n - 1)
             throw std::invalid_argument("nev must satisfy 1 <= nev <= n - 1, n is the size of matrix");

--- a/include/Util/SelectionRule.h
+++ b/include/Util/SelectionRule.h
@@ -8,7 +8,7 @@
 #define SELECTION_RULE_H
 
 #include <vector>     // std::vector
-#include <cmath>      // std::abs
+//#include <cmath>      // std::abs
 #include <algorithm>  // std::sort
 #include <complex>    // std::complex
 #include <utility>    // std::pair
@@ -94,10 +94,10 @@ public:
 
 // When comparing eigenvalues, we first calculate the "target"
 // to sort. For example, if we want to choose the eigenvalues with
-// largest magnitude, the target will be -std::abs(x).
+// largest magnitude, the target will be -abs(x).
 // The minus sign is due to the fact that std::sort() sorts in ascending order.
 
-// Default target: throw an exceptoin
+// Default target: throw an exception
 template <typename Scalar, int SelectionRule>
 class SortingTarget
 {
@@ -105,7 +105,7 @@ public:
     static typename ElemType<Scalar>::type get(const Scalar& val)
     {
         throw std::invalid_argument("incompatible selection rule");
-        return -std::abs(val);
+        return -abs(val);
     }
 };
 
@@ -117,7 +117,7 @@ class SortingTarget<Scalar, LARGEST_MAGN>
 public:
     static typename ElemType<Scalar>::type get(const Scalar& val)
     {
-        return -std::abs(val);
+        return -abs(val);
     }
 };
 
@@ -141,7 +141,7 @@ class SortingTarget<std::complex<RealType>, LARGEST_IMAG>
 public:
     static RealType get(const std::complex<RealType>& val)
     {
-        return -std::abs(val.imag());
+        return -abs(val.imag());
     }
 };
 
@@ -179,7 +179,7 @@ class SortingTarget<Scalar, SMALLEST_MAGN>
 public:
     static typename ElemType<Scalar>::type get(const Scalar& val)
     {
-        return std::abs(val);
+        return abs(val);
     }
 };
 
@@ -203,7 +203,7 @@ class SortingTarget<std::complex<RealType>, SMALLEST_IMAG>
 public:
     static RealType get(const std::complex<RealType>& val)
     {
-        return std::abs(val.imag());
+        return abs(val.imag());
     }
 };
 


### PR DESCRIPTION
...iler to choose the implementations of abs, sqrt, pow which is suited to the used type.

Thanks for the tip on adjusting the source code for other types than builtins like float and double! I did these changes and it works for me :-) It would be great if anyone using your code could benefit from this.

I couldn't check all the methods since I'm not sure how to use all of them... But I used DenseSymMatProd and SymEigsSolver and applied the same changes to all files.

Note that "#include <cmath>" is now commented out, since it is only needed if Scalar = float or double. It should thus be included in the files relying on Spectra if they choose to have fload or double matrices (before the Spectra includes).