### PR TITLE
Allow for non-default SparseMatrix template

### DIFF
--- a/include/MatOp/SparseCholesky.h
+++ b/include/MatOp/SparseCholesky.h
@@ -23,13 +23,13 @@ namespace Spectra {
 /// matrix. It is mainly used in the SymGEigsSolver generalized eigen solver
 /// in the Cholesky decomposition mode.
 ///
-template <typename Scalar, int Uplo = Eigen::Lower>
+template <typename Scalar, int Uplo = Eigen::Lower, int Flags = 0, typename StorageIndex = int>
 class SparseCholesky
 {
 private:
     typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 1> Vector;
     typedef Eigen::Map<Vector> MapVec;
-    typedef Eigen::SparseMatrix<Scalar> SparseMatrix;
+    typedef Eigen::SparseMatrix<Scalar, Flags, StorageIndex> SparseMatrix;
 
     const int m_n;
     Eigen::SimplicialLLT<SparseMatrix, Uplo> m_decomp;

--- a/include/MatOp/SparseGenMatProd.h
+++ b/include/MatOp/SparseGenMatProd.h
@@ -21,13 +21,13 @@ namespace Spectra {
 /// \f$x\f$. It is mainly used in the GenEigsSolver and SymEigsSolver
 /// eigen solvers.
 ///
-template <typename Scalar>
+template <typename Scalar, int Flags = 0, typename StorageIndex = int>
 class SparseGenMatProd
 {
 private:
     typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 1> Vector;
     typedef Eigen::Map<Vector> MapVec;
-    typedef Eigen::SparseMatrix<Scalar> SparseMatrix;
+    typedef Eigen::SparseMatrix<Scalar, Flags, StorageIndex> SparseMatrix;
 
     const SparseMatrix& m_mat;
 

--- a/include/MatOp/SparseGenRealShiftSolve.h
+++ b/include/MatOp/SparseGenRealShiftSolve.h
@@ -22,13 +22,13 @@ namespace Spectra {
 /// i.e., calculating \f$y=(A-\sigma I)^{-1}x\f$ for any real \f$\sigma\f$ and
 /// vector \f$x\f$. It is mainly used in the GenEigsRealShiftSolver eigen solver.
 ///
-template <typename Scalar>
+template <typename Scalar,int Flags = 0, typename StorageIndex = int>
 class SparseGenRealShiftSolve
 {
 private:
     typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 1> Vector;
     typedef Eigen::Map<Vector> MapVec;
-    typedef Eigen::SparseMatrix<Scalar> SparseMatrix;
+    typedef Eigen::SparseMatrix<Scalar, Flags, StorageIndex> SparseMatrix;
 
     const SparseMatrix& m_mat;
     const int m_n;

--- a/include/MatOp/SparseSymMatProd.h
+++ b/include/MatOp/SparseSymMatProd.h
@@ -20,13 +20,13 @@ namespace Spectra {
 /// sparse real symmetric matrix \f$A\f$, i.e., calculating \f$y=Ax\f$ for any vector
 /// \f$x\f$. It is mainly used in the SymEigsSolver eigen solver.
 ///
-template <typename Scalar, int Uplo = Eigen::Lower>
+template <typename Scalar, int Uplo = Eigen::Lower, int Flags = 0, typename StorageIndex = int>
 class SparseSymMatProd
 {
 private:
     typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 1> Vector;
     typedef Eigen::Map<Vector> MapVec;
-    typedef Eigen::SparseMatrix<Scalar> SparseMatrix;
+    typedef Eigen::SparseMatrix<Scalar, Flags, StorageIndex> SparseMatrix;
 
     const SparseMatrix& m_mat;
 

--- a/include/MatOp/SparseSymShiftSolve.h
+++ b/include/MatOp/SparseSymShiftSolve.h
@@ -22,13 +22,13 @@ namespace Spectra {
 /// i.e., calculating \f$y=(A-\sigma I)^{-1}x\f$ for any real \f$\sigma\f$ and
 /// vector \f$x\f$. It is mainly used in the SymEigsShiftSolver eigen solver.
 ///
-template <typename Scalar, int Uplo = Eigen::Lower>
+template <typename Scalar, int Uplo = Eigen::Lower, int Flags = 0, typename StorageIndex = int>
 class SparseSymShiftSolve
 {
 private:
     typedef Eigen::Matrix<Scalar, Eigen::Dynamic, 1> Vector;
     typedef Eigen::Map<Vector> MapVec;
-    typedef Eigen::SparseMatrix<Scalar> SparseMatrix;
+    typedef Eigen::SparseMatrix<Scalar, Flags, StorageIndex> SparseMatrix;
 
     const SparseMatrix& m_mat;
     const int m_n;


### PR DESCRIPTION
Currently the only `Eigen::SparseMatrix` available to Spectra is the default `SparseMatrix<Scalar>=SparseMatrix<Scalar,Eigen::ColMajor,int>`, and when passed something else (ex: `SparseMatrix<Scalar,ColMajor,long>`), a runtime error occurs with a rather cryptic `EXEC_BAD_ACCESS`. 
This commit allows for something like
```C++
Eigen::SparseMatrix<double,Eigen::ColMajor,long> m;
SparseGenMatProd<double,Eigen::ColMajor,long> op(m);
GenEigsSolver< double, LARGEST_MAGN, SparseGenMatProd<double,Eigen::ColMajor,long> > eigs(&op, 3, 6);
```