### PR TITLE
Type mismatch

### DIFF
--- a/include/Spectra/LinAlg/BKLDLT.h
+++ b/include/Spectra/LinAlg/BKLDLT.h
@@ -247,8 +247,8 @@ private:
                         // p >= k and r >= k+1, so it is safe to always make r > p
                         // One exception is when min{r,p} == k+1, in which case we make
                         // r = k+1, so that only one permutation needs to be performed
-                        const Scalar rp_min = std::min(r, p);
-                        const Scalar rp_max = std::max(r, p);
+                        const Index rp_min = std::min(r, p);
+                        const Index rp_max = std::max(r, p);
                         if(rp_min == k + 1)
                         {
                             r = rp_min; p = rp_max;


### PR DESCRIPTION
Hey @yixuan, thanks for keeping improving the code over the last years :+1: 

Just have a small change request : at this point of the code, both r and p variables are of type `Index` (may be different from `Scalar`), so it seems we should rather define `rp_min` and `rp_max` as variables of type `Index` as well...

This distinction makes a big difference in my usage of the Spectra library, so I would appreciate a quick fix if possible :-)