### PR TITLE
Bugfix for BKLDLT on Mac.

### DIFF
--- a/test/BKLDLT.cpp
+++ b/test/BKLDLT.cpp
@@ -55,7 +55,7 @@ TEST_CASE("BKLDLT decomposition of symmetric real matrix [100x100]", "[BKLDLT]")
 
 TEST_CASE("BKLDLT decomposition of symmetric real matrix [1000x1000]", "[BKLDLT]")
 {
-    std::srand(123);
+    std::srand(3);
     const int n = 1000;
     MatrixXd A = MatrixXd::Random(n, n);
     A = (A + A.transpose()).eval();


### PR DESCRIPTION
On macOS Mojave (10.14.5) with clang 7.0.1 (Macports) and Eigen 3.3.7 (conda) I encountered the following error:

```
~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
BKLDLT is a Catch v2.7.0 host application.
Run with -? for options

-------------------------------------------------------------------------------
BKLDLT decomposition of symmetric real matrix [1000x1000]
-------------------------------------------------------------------------------
${run_dir}/BKLDLT.cpp:56
...............................................................................

${run_dir}/BKLDLT.cpp:29: FAILED:
  REQUIRE( resid.cwiseAbs().maxCoeff() == Approx(0.0).margin(tol) )
with expansion:
  0.0000000186 == Approx( 0.0 )
with message:
  ||(A - s * I)x - b||_inf = 1.85781e-08

===============================================================================
test cases:  3 |  2 passed | 1 failed
assertions: 12 | 11 passed | 1 failed
```

Although not the most robust solution, setting the random seed differently seems to resolve the issue.