### PR TITLE
ArnoldiOp.h: warning: unused parameter 'Bop'

### DIFF
--- a/include/Spectra/MatOp/internal/ArnoldiOp.h
+++ b/include/Spectra/MatOp/internal/ArnoldiOp.h
@@ -109,7 +109,7 @@ private:
     OpType& m_op;
 
 public:
-    ArnoldiOp<Scalar, OpType, IdentityBOp>(OpType* op, IdentityBOp* Bop) :
+    ArnoldiOp<Scalar, OpType, IdentityBOp>(OpType* op, IdentityBOp* /*Bop*/) :
         m_op(*op)
     {}
 


### PR DESCRIPTION
Fixes the gcc warning:
```
include/Spectra/MatOp/internal/ArnoldiOp.h:112:69: warning: unused parameter 'Bop' [-Wunused-parameter]
```