### PR TITLE
Add support for Conda installers.

### DIFF
--- a/conda/build.sh
+++ b/conda/build.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+
+mkdir build && cd build
+if [ `uname` == Darwin ]; then
+    ${BUILD_PREFIX}/bin/cmake \
+        .. \
+        -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+        -DCMAKE_OSX_SYSROOT=${CONDA_BUILD_SYSROOT} \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_C_COMPILER=${CLANG} \
+        -DCMAKE_C_COMPILER=${CLANGXX} \
+        -DCMAKE_C_FLAGS="${CFLAGS} ${OPTS}" \
+        -DCMAKE_CXX_FLAGS="${CXXFLAGS} ${OPTS}" \
+        -DCMAKE_VERBOSE_MAKEFILE=TRUE \
+        -DBUILD_TESTS=TRUE
+fi
+if [ `uname` == Linux ]; then
+    ${BUILD_PREFIX}/bin/cmake \
+        .. \
+        -DCMAKE_INSTALL_PREFIX=${PREFIX} \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_C_COMPILER=${GCC} \
+        -DCMAKE_C_COMPILER=${GXX} \
+        -DCMAKE_C_FLAGS="${CFLAGS} ${OPTS}" \
+        -DCMAKE_CXX_FLAGS="${CXXFLAGS} ${OPTS}" \
+        -DCMAKE_VERBOSE_MAKEFILE=TRUE \
+        -DBUILD_TESTS=TRUE
+fi
+
+make -j${CPU_COUNT}
+make test ARGS=-j${CPU_COUNT}
+make install
+

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -1,0 +1,28 @@
+{% set version = "0.8.1" %}
+
+package:
+    name: spectra
+    version: {{ version }}
+source:
+    git_url: https://github.com/yixuan/spectra.git
+    git_tag: master
+requirements:
+    build:
+      - git
+      - make
+      - cmake {{ cmake }}
+      - {{ compiler('c') }}
+      - {{ compiler('cxx') }}
+      - llvm-openmp               # [osx]
+    host:
+      - eigen {{ eigen }}
+    run:
+      - {{ pin_compatible('eigen', min_pin='x.x', max_pin='x.x') }}
+test:
+  commands:
+    - test -f ${PREFIX}/include/Spectra/GenEigsBase.h
+about:
+    home: https://github.com/GQCG/spectra
+    license: Mozilla Public License 2.0 (MPL 2.0)
+    license_file: LICENSE
+    summary: 'A header-only C++ library for large scale eigenvalue problems.'

--- a/conda_build_config.yaml
+++ b/conda_build_config.yaml
@@ -1,0 +1,38 @@
+# Compilers
+
+c_compiler:
+  - clang                         # [osx]
+  - gcc                           # [linux]
+cxx_compiler:
+  - clangxx                       # [osx]
+  - gxx                           # [linux]
+fortran_compiler:
+  - gfortran
+target_platform:
+  - osx-64                        # [osx]
+  - linux-64                      # [linux]
+CONDA_BUILD_SYSROOT:
+  - /opt/MacOSX10.9.sdk      # [osx]
+
+# Packages
+blas_impl:
+  - mkl
+cmake:
+  - 3.14.0
+mkl:
+  - 2019
+pybind:
+  - 2.3.0
+python:
+  - 3.7
+  - 3.6
+numpy:
+  - 1.16.4
+eigen:
+  - 3.3.7
+
+pin_run_as_build:
+  mkl:
+    max_pin: x.x
+  intel_openmp:
+    max_pin: x.x


### PR DESCRIPTION
This PR adds support for [Conda](https://docs.conda.io/en/latest/) installers. Currently, you can install Spectra from our anaconda channel 

```bash
     conda install -c gqcg spectra
````

A more 'respected' channel of Conda packages is [Conda forge](https://conda-forge.org/). You can start from the supplied configuration files to have your package included into this channel.
