### PR TITLE
Add Github CI, checking formatting and code coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,7 @@
+coverage:
+  precision: 1
+  round: down
+  range: "70...100"
+ignore:
+  - /usr/include/
+  - test

--- a/.github/workflows/Basic.yml
+++ b/.github/workflows/Basic.yml
@@ -1,0 +1,29 @@
+name: Basic CI
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        mpi: [ ON, OFF ] 
+        compiler: [gcc, clang]
+        BUILD_TYPE : [Debug, Release]
+    steps:
+    - uses: actions/checkout@v2 
+    - name: blaslapack
+      run: sudo apt install libblas-dev liblapack-dev libopenmpi-dev
+    - name: configure
+      env:
+        CC: ${{ matrix.compiler }}
+      run: cmake -H. -Bbuild -DhpGEM_USE_MPI=${{ matrix.mpi }} -DENABLE_TESTING=ON -DCMAKEBUILD_TYPE=${{ matrix.BUILD_TYPE }}
+    - name: make
+      run: cmake --build build -- -j4
+    - name: test
+      run: cd build && ctest

--- a/.github/workflows/Basic.yml
+++ b/.github/workflows/Basic.yml
@@ -12,17 +12,16 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        mpi: [ ON, OFF ] 
         compiler: [gcc, clang]
         BUILD_TYPE : [Debug, Release]
     steps:
     - uses: actions/checkout@v2 
-    - name: blaslapack
-      run: sudo apt install libblas-dev liblapack-dev libopenmpi-dev
+    - name: dependencies
+      run: sudo apt install libeigen3-dev
     - name: configure
       env:
         CC: ${{ matrix.compiler }}
-      run: cmake -H. -Bbuild -DhpGEM_USE_MPI=${{ matrix.mpi }} -DENABLE_TESTING=ON -DCMAKEBUILD_TYPE=${{ matrix.BUILD_TYPE }}
+      run: cmake -H. -Bbuild  -DBUILD_TESTS=ON -DCMAKEBUILD_TYPE=${{ matrix.BUILD_TYPE }}
     - name: make
       run: cmake --build build -- -j4
     - name: test

--- a/.github/workflows/checkformat.yml
+++ b/.github/workflows/checkformat.yml
@@ -16,5 +16,7 @@ jobs:
     - uses: actions/checkout@v2 
     - name: dependencies
       run: sudo apt install libeigen3-dev clang-format-8
-    - name: check_format
-      run: cmake --build . --target format && git diff --exit-code
+    - name: cmake
+      run: cmake -B builddir
+    - name: Format
+      run: cmake --build builddir --target format && git diff --exit-code

--- a/.github/workflows/checkformat.yml
+++ b/.github/workflows/checkformat.yml
@@ -22,4 +22,4 @@ jobs:
         CC: ${{ matrix.compiler }}
       run: cmake -H. -Bbuild -DBUILD_TESTS=ON -DCMAKEBUILD_TYPE=${{ matrix.BUILD_TYPE }} -DENABLE_COVERAGE_BUILD=ON
     - name: check_format
-      run: cmake --build --target format && git diff --exit-code
+      run: cmake --build . --target format && git diff --exit-code

--- a/.github/workflows/checkformat.yml
+++ b/.github/workflows/checkformat.yml
@@ -20,6 +20,6 @@ jobs:
     - name: configure
       env:
         CC: ${{ matrix.compiler }}
-      run: cmake -H. -Bbuild -DBUILD_TESTS=ON -DCMAKEBUILD_TYPE=${{ matrix.BUILD_TYPE }} -DENABLE_COVERAGE_BUILD=ON
+      run: cmake -H. -Bbuild -DBUILD_TESTS=ON -DCMAKEBUILD_TYPE=${{ matrix.BUILD_TYPE }}
     - name: check_format
-      run: cmake --target format && git diff --exit-code
+      run: cmake --build . --target format && git diff --exit-code

--- a/.github/workflows/checkformat.yml
+++ b/.github/workflows/checkformat.yml
@@ -1,4 +1,4 @@
-name: Codecov
+name: check format
 on:
   push:
     branches: [ master ]
@@ -16,14 +16,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2 
     - name: dependencies
-      run: sudo apt install libeigen3-dev
+      run: sudo apt install libeigen3-dev clang-format-8
     - name: configure
       env:
         CC: ${{ matrix.compiler }}
       run: cmake -H. -Bbuild -DBUILD_TESTS=ON -DCMAKEBUILD_TYPE=${{ matrix.BUILD_TYPE }} -DENABLE_COVERAGE_BUILD=ON
-    - name: make
-      run: cmake --build build -- -j4
-    - name: test
-      run: cd build && ctest
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
+    - name: check_format
+      run: cmake --build --target format && git diff --exit-code

--- a/.github/workflows/checkformat.yml
+++ b/.github/workflows/checkformat.yml
@@ -12,14 +12,9 @@ jobs:
     strategy:
       matrix:
         compiler: [gcc]
-        BUILD_TYPE : [Debug]
     steps:
     - uses: actions/checkout@v2 
     - name: dependencies
       run: sudo apt install libeigen3-dev clang-format-8
-    - name: configure
-      env:
-        CC: ${{ matrix.compiler }}
-      run: cmake -H. -Bbuild -DBUILD_TESTS=ON -DCMAKEBUILD_TYPE=${{ matrix.BUILD_TYPE }}
     - name: check_format
       run: cmake --build . --target format && git diff --exit-code

--- a/.github/workflows/checkformat.yml
+++ b/.github/workflows/checkformat.yml
@@ -22,4 +22,4 @@ jobs:
         CC: ${{ matrix.compiler }}
       run: cmake -H. -Bbuild -DBUILD_TESTS=ON -DCMAKEBUILD_TYPE=${{ matrix.BUILD_TYPE }} -DENABLE_COVERAGE_BUILD=ON
     - name: check_format
-      run: cmake --build . --target format && git diff --exit-code
+      run: cmake --target format && git diff --exit-code

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -1,0 +1,28 @@
+name: Codecov
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        mpi: [ ON] 
+        compiler: [gcc]
+        BUILD_TYPE : [Debug]
+    steps:
+    - uses: actions/checkout@v2 
+    - name: configure
+      env:
+        CC: ${{ matrix.compiler }}
+      run: cmake -H. -Bbuild -DENABLE_TESTING=ON -DCMAKEBUILD_TYPE=${{ matrix.BUILD_TYPE }} -DENABLE_COVERAGE_BUILD=ON
+    - name: make
+      run: cmake --build build -- -j4
+    - name: test
+      run: cd build && ctest
+    - name: Upload coverage to Codecov
+      uses: codecov/codecov-action@v1

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,16 @@ project (Spectra VERSION 0.8.1 LANGUAGES CXX)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake)  # make CMake look into the ./cmake/ folder for configuration files
 
+option(ENABLE_COVERAGE_BUILD "Do a coverage build" OFF)
+if(ENABLE_COVERAGE_BUILD)
+    message(STATUS "Enabling coverage build")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} --coverage")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} --coverage")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} --coverage")
+    set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} --coverage")
+endif()
+
+
 # Supported options
 # -----------------
 option(BUILD_TESTS "Build tests" OFF)

--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ More information can be found in the project page [https://spectralib.org](https
 
 ## Installation
 
-An optional CMake installation is supported, if you have CMake with at least v3.13 installed. You can install the headers using the following commands:
+An optional CMake installation is supported, if you have CMake installed. You can install the headers using the following commands:
 
 ```bash
     mkdir build && cd build

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # <a href="https://spectralib.org"><img src="https://spectralib.org/img/logo.png" width="200px" /></a>
 
-[![Build Status](https://travis-ci.org/yixuan/spectra.svg?branch=master)](https://travis-ci.org/yixuan/spectra)
+[![Build Status](https://travis-ci.org/yixuan/spectra.svg?branch=master)](https://travis-ci.org/yixuan/spectra) ![Basic CI](https://github.com/JensWehner/spectra/workflows/Basic%20CI/badge.svg) [![codecov](https://codecov.io/gh/JensWehner/spectra/branch/master/graph/badge.svg)](https://codecov.io/gh/JensWehner/spectra)
+
+
 
 > **NOTE**: If you are interested in the future development of Spectra, please join
 > [this thread](https://github.com/yixuan/spectra/issues/92) to share your comments and suggestions.


### PR DESCRIPTION
This PR adds a basic CI using Github actions:

it checks:
- Formatting of PRs
- that tests run with clang,gcc on ubuntu in debug and release mode
- looks if new PRs lower the code coverage

additionally I added a few badges, to show the new features in the readme.

Caveat: At the moment the badges point to my fork, @yixuan you would have to sign up to codecov.io with your github account and update the link.

@yixuan You could also update the settings in this project so that master is protected and tests have to run before a PR can be merged. See https://github.com/JensWehner/spectra/pull/4 as how it would look. 