### PR TITLE
CMake: Install config files under /usr/share/

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,7 +58,7 @@ install(DIRECTORY ${CMAKE_SOURCE_DIR}/include/ DESTINATION include)
 install(EXPORT Spectra-targets
 	FILE Spectra-targets.cmake
 	NAMESPACE Spectra::
-	DESTINATION cmake
+	DESTINATION share/spectra/cmake
 	)
 
 # Configure package
@@ -69,7 +69,7 @@ include(CMakePackageConfigHelpers)
 configure_package_config_file(
     ${CMAKE_SOURCE_DIR}/cmake/spectra-config.cmake.in
     ${CMAKE_BINARY_DIR}/cmake/spectra-config.cmake
-    INSTALL_DESTINATION cmake
+    INSTALL_DESTINATION share/spectra/cmake
 )
 
 write_basic_package_version_file(
@@ -82,7 +82,7 @@ install(
     FILES
         ${CMAKE_BINARY_DIR}/cmake/spectra-config.cmake
         ${CMAKE_BINARY_DIR}/cmake/spectra-config-version.cmake
-    DESTINATION cmake
+    DESTINATION share/spectra/cmake
 )
 
 find_package(CLANG_FORMAT 7.0.1)


### PR DESCRIPTION
/usr/cmake is an invalid location for linux packages, /usr/share/ (or /usr/lib) is a better location