### PR TITLE
C++20 compatability fix

### DIFF
--- a/include/Spectra/MatOp/internal/ArnoldiOp.h
+++ b/include/Spectra/MatOp/internal/ArnoldiOp.h
@@ -113,7 +113,7 @@ private:
     const OpType& m_op;
 
 public:
-    ArnoldiOp<Scalar, OpType, IdentityBOp>(const OpType& op, const IdentityBOp& /*Bop*/) :
+    ArnoldiOp(const OpType& op, const IdentityBOp& /*Bop*/) :
         m_op(op)
     {}
 


### PR DESCRIPTION
Per [this](https://stackoverflow.com/questions/63513984/can-class-template-constructors-have-a-redundant-template-parameter-list-in-c2), the code needed a minor change when building using the c++20 standard (tested with g++11.1.0). 

