### PR TITLE
Added CMake options to manage the Eigen dependency.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,9 +21,22 @@ include(FeatureSummary) # More verbose Output for libraries using set_package_pr
 
 # Look for supporting libraries
 # -----------------------------
-find_package(Eigen3 NO_MODULE REQUIRED)
-set_package_properties(Eigen3 PROPERTIES TYPE REQUIRED PURPOSE "C++ vector data structures")
-message(STATUS "Found Eigen3 Version: ${Eigen3_VERSION} Path: ${Eigen3_DIR}")
+if (NOT TARGET Eigen3::Eigen)
+    option(USE_SYSTEM_EIGEN "Use the system Eigen" ON)
+    find_package(Eigen3 NO_MODULE)
+    if(USE_SYSTEM_EIGEN AND ${Eigen3_FOUND})
+        set_package_properties(Eigen3 PROPERTIES TYPE REQUIRED PURPOSE "C++ vector data structures")
+        message(STATUS "Found Eigen3 Version: ${Eigen3_VERSION} Path: ${Eigen3_DIR}")
+    else()
+        include(FetchContent)
+        FetchContent_Declare(
+          eigen3 
+          GIT_REPOSITORY https://gitlab.com/libeigen/eigen
+          GIT_TAG 3.4.0
+        )
+        FetchContent_MakeAvailable(eigen3)
+    endif()
+endif()
 
 # Setup library
 # -------------


### PR DESCRIPTION
This does a few things to provide more options for managing the Eigen dependency in downstream projects.

- If the `find_package` works and `USE_SYSTEM_EIGEN` is set to `ON` (the default), the system Eigen is directly used. This preserves the behavior of the current approach.
- If either of the two conditions above is false, we `FetchContent` the latest version of Eigen directly and expose its targets for downstream use. This means that Spectra will work without requiring users to pre-install Eigen; it is also necessary for certain buildchains that don't work with the usual `find_package` (in my case, Emscripten, for compiling to Webassembly).
- The entire section is only evaluated if `Eigen3::Eigen` is not already available as a target. This allows projects to easily control how Eigen is made available without having to worry about conflicts with Spectra's definition.