### PR TITLE
CMake: include Eigen targets

### DIFF
--- a/cmake/spectra-config.cmake.in
+++ b/cmake/spectra-config.cmake.in
@@ -1,5 +1,7 @@
 @PACKAGE_INIT@
 
+find_package (Eigen3 CONFIG)
+
 if(NOT TARGET Spectra::Spectra)
   include(${CMAKE_CURRENT_LIST_DIR}/Spectra-targets.cmake)
 endif()


### PR DESCRIPTION
The targets file links to the Eigen3::Eigen target so we must include here instead of the client side