### PR TITLE
Use GNUInstallDirs; Fix install location of CMake config files; include CMakeFindDependencyMacro module

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,16 +64,16 @@ include(GNUInstallDirs)
 install(
     TARGETS Spectra
     EXPORT Spectra-targets
-    INCLUDES DESTINATION include
+    INCLUDES DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
 )
 
-install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/ DESTINATION include)
+install(DIRECTORY ${PROJECT_SOURCE_DIR}/include/ DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 
 install(
     EXPORT Spectra-targets
     FILE Spectra-targets.cmake
     NAMESPACE Spectra::
-    DESTINATION share/spectra/cmake
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/Spectra
 )
 
 # Configure package
@@ -83,7 +83,7 @@ include(CMakePackageConfigHelpers)
 configure_package_config_file(
     ${PROJECT_SOURCE_DIR}/cmake/spectra-config.cmake.in
     ${CMAKE_BINARY_DIR}/cmake/spectra-config.cmake
-    INSTALL_DESTINATION share/spectra/cmake
+    INSTALL_DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/Spectra
 )
 
 write_basic_package_version_file(
@@ -96,7 +96,7 @@ install(
     FILES
         ${CMAKE_BINARY_DIR}/cmake/spectra-config.cmake
         ${CMAKE_BINARY_DIR}/cmake/spectra-config-version.cmake
-    DESTINATION share/spectra/cmake
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/cmake/Spectra
 )
 
 find_package(CLANG_FORMAT 9)

--- a/cmake/spectra-config.cmake.in
+++ b/cmake/spectra-config.cmake.in
@@ -1,5 +1,6 @@
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
 find_dependency (Eigen3 CONFIG)
 
 if(NOT TARGET Spectra::Spectra)

--- a/cmake/spectra-config.cmake.in
+++ b/cmake/spectra-config.cmake.in
@@ -1,6 +1,5 @@
 @PACKAGE_INIT@
 
-include(CMakeFindDependencyMacro)
 find_dependency (Eigen3 CONFIG)
 
 if(NOT TARGET Spectra::Spectra)


### PR DESCRIPTION
@yixuan The PR does the following things:

- Use `GNUInstallDirs`. There are some reasonable variables that can be used to faciliate the installation in CMake, instead of the hard-coded path.
- Fix install location of CMake config files. It should be `${CMAKE_INSTALL_DATADIR}/cmake/Spectra` not `share/spectra/cmake`, in Linux as I know.
- Add `include(CMakeFindDependencyMacro)` before using `find_dependency`. https://cmake.org/cmake/help/latest/module/CMakeFindDependencyMacro.html