### PR TITLE
Update CMakeLists.txt: Be a bit more flexible towards linking Eigen

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,7 @@ target_include_directories(
     $<INSTALL_INTERFACE:include>
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
 )
-target_link_libraries(Spectra INTERFACE Eigen3::Eigen)
+target_link_libraries(Spectra INTERFACE ${EIGEN3_LIBRARIES})
 
 # Parse additional options
 # ------------------------

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,7 +36,11 @@ target_include_directories(
     $<INSTALL_INTERFACE:include>
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
 )
-target_link_libraries(Spectra INTERFACE ${EIGEN3_LIBRARIES})
+if (DEFINED EIGEN3_LIBRARIES)
+    target_link_libraries(Spectra INTERFACE ${EIGEN3_LIBRARIES})
+else()
+    target_link_libraries(Spectra INTERFACE Eigen3::Eigen)
+endif()
 
 # Parse additional options
 # ------------------------


### PR DESCRIPTION
This change allows me to use `FetchContent_Declare` for both `Eigen3` as well as `Spectra`.