### PR TITLE
CMake: Bump minimum version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required (VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required (VERSION 3.10 FATAL_ERROR)
 project (Spectra VERSION 1.1.0 LANGUAGES CXX)
 
 # Make CMake look into the ./cmake/ folder for configuration files


### PR DESCRIPTION
Avoids this deprecation message:

```
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.10 will be removed from a future version of
  CMake.
```