### PR TITLE
Misc bugs

### DIFF
--- a/include/Spectra/LinAlg/Arnoldi.h
+++ b/include/Spectra/LinAlg/Arnoldi.h
@@ -122,7 +122,7 @@ public:
 
     // Move an ArnoldiOp
     Arnoldi(ArnoldiOpType&& op, Index m) :
-        m_op(std::move(op)), m_n(op.rows()), m_m(m), m_k(0)
+        m_op(std::move(op)), m_n(m_op.rows()), m_m(m), m_k(0)
     {}
 
     // Const-reference to internal structures

--- a/include/Spectra/LinAlg/DoubleShiftQR.h
+++ b/include/Spectra/LinAlg/DoubleShiftQR.h
@@ -282,8 +282,8 @@ private:
         const Scalar u0 = m_ref_u.coeff(0, u_ind), u1 = m_ref_u.coeff(1, u_ind);
         const Scalar u0_2 = Scalar(2) * u0, u1_2 = Scalar(2) * u1;
 
-        const int nrow = X.rows();
-        const int ncol = X.cols();
+        const Index nrow = X.rows();
+        const Index ncol = X.cols();
         Scalar *X0 = X.data(), *X1 = X0 + stride;  // X0 => X.col(0), X1 => X.col(1)
 
         if (nr == 2 || ncol == 2)

--- a/include/Spectra/Util/SelectionRule.h
+++ b/include/Spectra/Util/SelectionRule.h
@@ -204,7 +204,7 @@ private:
 
 public:
     // Sort indices according to the eigenvalues they point to
-    inline bool operator()(Index i, Index j)
+    inline bool operator()(Index i, Index j) const
     {
         return SortingTarget<T, Rule>::get(m_evals[i]) < SortingTarget<T, Rule>::get(m_evals[j]);
     }

--- a/include/Spectra/Util/SimpleRandom.h
+++ b/include/Spectra/Util/SimpleRandom.h
@@ -34,8 +34,8 @@ inline long next_long_rand(long seed)
 
     unsigned long lo, hi;
 
-    lo = m_a * (long) (seed & 0xFFFF);
-    hi = m_a * (long) ((unsigned long) seed >> 16);
+    lo = (unsigned long) m_a * (unsigned long) (seed & 0xFFFFUL);
+    hi = (unsigned long) m_a * (unsigned long) ((unsigned long) seed >> 16);
     lo += (hi & 0x7FFF) << 16;
     if (lo > m_max)
     {

--- a/include/Spectra/contrib/PartialSVDSolver.h
+++ b/include/Spectra/contrib/PartialSVDSolver.h
@@ -8,6 +8,7 @@
 #define SPECTRA_PARTIAL_SVD_SOLVER_H
 
 #include <Eigen/Core>
+#include <memory>
 #include "../SymEigsSolver.h"
 
 namespace Spectra {
@@ -125,8 +126,8 @@ private:
     ConstGenericMatrix m_mat;
     const Index m_m;
     const Index m_n;
-    SVDMatOp<Scalar>* m_op;
-    SymEigsSolver<SVDMatOp<Scalar>>* m_eigs;
+    std::unique_ptr<SVDMatOp<Scalar>> m_op;
+    std::unique_ptr<SymEigsSolver<SVDMatOp<Scalar>>> m_eigs;
     Index m_nconv;
     Matrix m_evecs;
 
@@ -138,23 +139,18 @@ public:
         // Determine the matrix type, tall or wide
         if (m_m > m_n)
         {
-            m_op = new SVDTallMatOp<Scalar, MatrixType>(mat);
+            m_op.reset(new SVDTallMatOp<Scalar, MatrixType>(mat));
         }
         else
         {
-            m_op = new SVDWideMatOp<Scalar, MatrixType>(mat);
+            m_op.reset(new SVDWideMatOp<Scalar, MatrixType>(mat));
         }
 
         // Solver object
-        m_eigs = new SymEigsSolver<SVDMatOp<Scalar>>(*m_op, ncomp, ncv);
+        m_eigs.reset(new SymEigsSolver<SVDMatOp<Scalar>>(*m_op, ncomp, ncv));
     }
 
-    // Destructor
-    virtual ~PartialSVDSolver()
-    {
-        delete m_eigs;
-        delete m_op;
-    }
+    ~PartialSVDSolver() = default;
 
     // Computation
     Index compute(Index maxit = 1000, Scalar tol = 1e-10)


### PR DESCRIPTION
- SelectionRule.h: Add missing const qualifier on SortEigenvalue::operator() required by std::sort comparator contract
- SimpleRandom.h: Fix platform-dependent integer overflow in LCG PRNG by using consistent unsigned long casts
- Arnoldi.h: Fix use-after-move in constructor where op.rows() was called after std::move(op); use m_op.rows() instead
- PartialSVDSolver.h: Replace raw new/delete with std::unique_ptr to fix exception-safety memory leak and simplify destructor
- DoubleShiftQR.h: Use Index instead of int for matrix dimensions to avoid narrowing conversion from Eigen::Index